### PR TITLE
Handle JSON pointer refs in schema processing

### DIFF
--- a/src/mcpo/main.py
+++ b/src/mcpo/main.py
@@ -283,6 +283,7 @@ async def create_dynamic_endpoints(app: FastAPI, api_dependency=None):
             inputSchema.get("properties", {}),
             inputSchema.get("required", []),
             inputSchema.get("$defs", {}),
+            inputSchema,
         )
 
         response_model_fields = None
@@ -292,6 +293,7 @@ async def create_dynamic_endpoints(app: FastAPI, api_dependency=None):
                 outputSchema.get("properties", {}),
                 outputSchema.get("required", []),
                 outputSchema.get("$defs", {}),
+                outputSchema,
             )
 
         tool_handler = get_tool_handler(


### PR DESCRIPTION
## Summary
- add a JSON Pointer resolver to walk schema references instead of relying on the last path segment
- update schema processing to merge nested `$defs`, resolve references from the root schema, and propagate that context through nested calls
- cover the new resolver with a regression test that exercises a `#/$defs/.../properties/...` reference

## Testing
- uv run pytest *(fails: cannot reach pypi.org while downloading dependencies)*
- pytest *(fails: ModuleNotFoundError: No module named 'typer')*


------
https://chatgpt.com/codex/tasks/task_b_68cd978901388327a6faf83b0a92f6df